### PR TITLE
[ParseAlterQuery] Support multiple spaces when parsing alter statements

### DIFF
--- a/sqlparse/utils.go
+++ b/sqlparse/utils.go
@@ -20,7 +20,7 @@ func ParseAlterQuery(str string) (bool, alterQuery) {
 	str = strings.Replace(str, "\n", " ", -1)
 	str = strings.Replace(str, ";", ";\n", -1)
 
-	re = regexp.MustCompile(`(?m)^(?:.*)ALTER\sTABLE\s(\S*)\s(.*);$`)
+	re = regexp.MustCompile(`(?m)^(?:.*)ALTER\s+TABLE\s+(\S*)\s+(.*);$`)
 
 	match := re.FindStringSubmatch(str)
 	if match != nil {

--- a/sqlparse/utils_test.go
+++ b/sqlparse/utils_test.go
@@ -1,20 +1,50 @@
 package sqlparse
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestParseSQL(t *testing.T) {
 	var tests = []struct {
 		input string
 		want  alterQuery
 	}{
-		{"ALTER TABLE `Box` ADD COLUMN `column` INT NOT NULL DEFAULT 0;", alterQuery{Action: "ADD COLUMN `column` INT NOT NULL DEFAULT 0", Table: "Box"}},
-		{"ALTER TABLE User DROP COLUMN profile;", alterQuery{Action: "DROP COLUMN profile", Table: "User"}},
-		{`
+		{
+			input: "ALTER TABLE `Box` ADD COLUMN `column` INT NOT NULL DEFAULT 0;",
+			want: alterQuery{
+				Action: "ADD COLUMN `column` INT NOT NULL DEFAULT 0",
+				Table:  "Box",
+			},
+		},
+		{
+			input: "ALTER TABLE User DROP COLUMN profile;",
+			want: alterQuery{
+				Action: "DROP COLUMN profile",
+				Table:  "User",
+			},
+		},
+		{
+			input: `
 			ALTER TABLE User DROP COLUMN profile;
-			`, alterQuery{Action: "DROP COLUMN profile", Table: "User"}},
-		{`
+			`,
+			want: alterQuery{
+				Action: "DROP COLUMN profile",
+				Table:  "User",
+			},
+		},
+		{
+			input: `
 				UPDATE SubscriptionLog SET userVendorToken = "" WHERE userVendorToken IS NULL;
-				`, alterQuery{}},
+				`,
+			want: alterQuery{},
+		},
+		{
+			input: "ALTER TABLE  `Contract`  MODIFY city varchar(50) NOT NULL DEFAULT '';",
+			want: alterQuery{
+				Action: "MODIFY city varchar(50) NOT NULL DEFAULT ''",
+				Table:  "Contract",
+			},
+		},
 	}
 	for _, test := range tests {
 		if _, got := ParseAlterQuery(test.input); got != test.want {


### PR DESCRIPTION
To prevent the error is shown in the picture below.

![image (13)](https://user-images.githubusercontent.com/30612032/68111874-1905d500-ff2b-11e9-9816-8cdb47100620.png)
